### PR TITLE
PHP 7.2 and 8.0 support 🚀 and Laravel 6.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 7.4
 
 env:
+  - LARAVEL=^6.0
   - LARAVEL=^7.0
   - LARAVEL=^8.0
 
@@ -20,7 +21,7 @@ cache:
 install:
   - travis_retry composer install --no-suggest --no-interaction --prefer-dist --no-progress
 
-script: 
+script:
   - ./vendor/bin/phpunit --coverage-clover build/logs/clover.xml
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,23 @@
 language: php
 
 php:
+  - 7.2
   - 7.3
   - 7.4
+  - 8.0snapshot
 
 env:
   - LARAVEL=^6.0
   - LARAVEL=^7.0
   - LARAVEL=^8.0
 
-matrix:
-  fast_finish: true
-  allow_failures:
-    - php: 7.4
-
 cache:
   directories:
     - $HOME/.composer/cache
 
 install:
-  - travis_retry composer install --no-suggest --no-interaction --prefer-dist --no-progress
+  - travis_retry composer self-update
+  - travis_retry composer install --no-interaction --prefer-dist --no-progress
 
 script:
   - ./vendor/bin/phpunit --coverage-clover build/logs/clover.xml

--- a/composer.json
+++ b/composer.json
@@ -29,15 +29,15 @@
         "php": ">=7.3",
         "guzzlehttp/guzzle": "^6.2",
         "aws/aws-sdk-php": "~3.0",
-        "illuminate/contracts": "^7.0|^8.0",
-        "illuminate/database": "^7.0|^8.0",
-        "illuminate/queue": "^7.0|^8.0",
-        "illuminate/console": "^7.0|^8.0",
+        "illuminate/contracts": "^6.0|^7.0|^8.0",
+        "illuminate/database": "^6.0|^7.0|^8.0",
+        "illuminate/queue": "^6.0|7.0|^8.0",
+        "illuminate/console": "^6.0|^7.0|^8.0",
         "twig/twig": "~3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5",
-        "mockery/mockery": "^1.2.1",
+        "mockery/mockery": "^1.4.2",
         "gecko-packages/gecko-memcache-mock": "^1.0"
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
           "email": "thomas.manley@generationtux.com"
         }
     ],
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "autoload": {
         "psr-4": {
             "Gentux\\Healthz\\": "src/"
@@ -26,8 +27,8 @@
         ]
     },
     "require": {
-        "php": ">=7.3",
-        "guzzlehttp/guzzle": "^6.2|^7.0.1",
+        "php": ">=7.2.5",
+        "guzzlehttp/guzzle": "^6.2",
         "aws/aws-sdk-php": "~3.0",
         "illuminate/contracts": "^6.0|^7.0|^8.0",
         "illuminate/database": "^6.0|^7.0|^8.0",
@@ -36,8 +37,8 @@
         "twig/twig": "~3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.5|^9.0",
-        "mockery/mockery": "^1.4.2",
+        "phpunit/phpunit": "^8.4|^9.3.3",
+        "mockery/mockery": "~1.3.3|^1.4.2",
         "gecko-packages/gecko-memcache-mock": "^1.0"
     },
     "extra": {


### PR DESCRIPTION
Support PHP from 7.2 to 8.0 and also Laravel 6.0 (because it's the current LTS version) to 8.0

Reference: https://laravel.com/docs/8.x/releases#support-policy