### PR TITLE
Downgrade Twig from 3.0 to 1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "illuminate/database": "^7.0|^8.0",
         "illuminate/queue": "^7.0|^8.0",
         "illuminate/console": "^7.0|^8.0",
-        "twig/twig": "~3.0"
+        "twig/twig": "~1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5",


### PR DESCRIPTION
To fix `Class 'Twig_Loader_Array' not found` error, when visiting the `/healthz/ui` URL

Close #18