### PR TITLE
Use Illuminate\Support\Arr::get() instead of array_get()

### DIFF
--- a/src/Support/HealthzServiceProvider.php
+++ b/src/Support/HealthzServiceProvider.php
@@ -2,6 +2,7 @@
 namespace Gentux\Healthz\Support;
 
 use Gentux\Healthz\Healthz;
+use Illuminate\Support\Arr;
 use Illuminate\Support\ServiceProvider;
 
 class HealthzServiceProvider extends ServiceProvider
@@ -51,8 +52,8 @@ class HealthzServiceProvider extends ServiceProvider
             $password = getenv('HEALTHZ_PASSWORD');
             if ($username != "") {
                 if (
-                    array_get($_SERVER, 'PHP_AUTH_USER') !== $username ||
-                    array_get($_SERVER, 'PHP_AUTH_PW') !== $password
+                    Arr::get($_SERVER, 'PHP_AUTH_USER') !== $username ||
+                    Arr::get($_SERVER, 'PHP_AUTH_PW') !== $password
                 ) {
                     return response('Invalid credentials', 401, ['WWW-Authenticate' => 'Basic']);
                 }


### PR DESCRIPTION
Because since Laravel 6, function helpers are not included in Laravel by default.

Source: https://laravel.com/docs/6.x/upgrade#helpers