### PR TITLE
Fix HealthResult::description() return signature

### DIFF
--- a/src/HealthResult.php
+++ b/src/HealthResult.php
@@ -71,9 +71,9 @@ class HealthResult
     }
 
     /**
-     * @return string
+     * @return null|string
      */
-    public function description(): string
+    public function description(): ?string
     {
         return $this->check->description();
     }


### PR DESCRIPTION
`HealthResult::description()`, which proxy the `HealthCheck::description()` method, must have the same return signature.

Otherwise it can thrown this error:
```
Symfony\Component\Debug\Exception\FatalThrowableError: /my_laravel_app/html/vendor/generationtux/healthz/src/HealthResult.php:78 Return value of Gentux\Healthz\HealthResult::description() must be of the type string, null returned
```

