### PR TITLE
Support Laravel 9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: test
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:
@@ -11,7 +11,7 @@ jobs:
     strategy: 
       fail-fast: false
       matrix:
-        php: [ 7.3, 7.4 ]
+        php: [ 7.3, 7.4, 8.0, 8.1 ]
         os: [ ubuntu-latest ]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: test
 
-on: [push, pull_request]
+on: [push, pull_request_target]
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy: 
       fail-fast: false
       matrix:
-        php: [ 7.3, 7.4, 8.0, 8.1 ]
+        php: [ "7.3", "7.4", "8.0", "8.1" ]
         os: [ ubuntu-latest ]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,12 @@ jobs:
       with:
         php-version: ${{ matrix.php }}
 
+    - name: Cache Composer dependencies
+      uses: actions/cache@v2
+      with:
+        path: /tmp/composer-cache
+        key: ${{ runner.os }}-${{ hashFiles('**/composer.lock') }}
+
     - name: Install Dependencies
       uses: php-actions/composer@master
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,11 @@
 name: test
 
-on: [push, pull_request_target]
+on:
+  push:
+  pull_request:
+    types:
+      - opened
+      - synchronize
 
 jobs:
   build:

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     },
     "require": {
         "php": ">=7.2.5",
-        "guzzlehttp/guzzle": "^6.2|^7.0.1",
+        "guzzlehttp/guzzle": "^6.2|^7.0.1|^7.2",
         "aws/aws-sdk-php": "~3.0",
         "illuminate/contracts": "^6.0|^7.0|^8.0",
         "illuminate/database": "^6.0|^7.0|^8.0",


### PR DESCRIPTION
Fixes https://github.com/generationtux/php-healthz/issues/27.

Laravel 9 requires PHP 8.0 or latest and `"guzzlehttp/guzzle": "^7.2"`. Checkout https://github.com/laravel/framework/blob/da859e7c1d67278d79ad95410c7656e6b4f8e7be/composer.json#L89.