### PR TITLE
php 8 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.3-fpm-alpine
+FROM php:8.1-fpm-alpine
 
 # The following labels need to be set as part of the docker build process.
 #   org.opencontainers.image.created
@@ -17,7 +17,7 @@ COPY ./docker/installComposer.sh /tmp/installComposer.sh
 
 RUN apk --no-cache --update add bash ca-certificates libpq postgresql-dev curl git curl git mysql-client unzip wget zip postgresql-client \
     && apk add --no-cache --virtual build-dependencies autoconf build-base g++ make \
-    && pecl install redis xdebug \
+    && pecl install redis xdebug-3.1.4 \
     && docker-php-ext-install bcmath opcache pdo_mysql pdo_pgsql pcntl \
     && docker-php-ext-enable bcmath opcache redis xdebug \
     && chmod +x /tmp/installComposer.sh \

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         ]
     },
     "require": {
-        "php": ">=7.2.5",
+        "php": ">=7.2.5|^8.0",
         "guzzlehttp/guzzle": "^6.2|^7.0.1|^7.2",
         "aws/aws-sdk-php": "~3.0",
         "illuminate/contracts": "^6.0|^7.0|^8.0",
@@ -38,8 +38,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^8.4|^9.3.3",
-        "mockery/mockery": "~1.3.3|^1.4.2",
-        "gecko-packages/gecko-memcache-mock": "^1.0"
+        "mockery/mockery": "~1.3.3|^1.4.2"
     },
     "extra": {
         "laravel": {

--- a/tests/Checks/General/MemcachedHealthCheckTest.php
+++ b/tests/Checks/General/MemcachedHealthCheckTest.php
@@ -9,10 +9,9 @@ namespace {
 
 namespace Gentux\Healthz\Checks\General {
 
-    use Gentux\Healthz\Checks\General\MemcachedHealthCheck;
     use Mockery;
     use Gentux\Healthz\HealthCheck;
-    use GeckoPackages\MemcacheMock\MemcachedMock;
+    use Memcached;
 
     class MemcachedHealthCheckTest extends \TestCase
     {
@@ -26,7 +25,7 @@ namespace Gentux\Healthz\Checks\General {
         public function setUp(): void
         {
             parent::setUp();
-            $this->memcached = Mockery::mock(MemcachedMock::class);
+            $this->memcached = Mockery::mock(Memcached::class);
             $this->health = new MemcachedHealthCheck($this->memcached);
         }
 


### PR DESCRIPTION
* Updates Dockerfile to run php 8.1
* Removes `gecko-packages/gecko-memcache-mock`as a dependency (it's abandoned) 
