### PR TITLE
Support Laravel 10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy: 
       fail-fast: false
       matrix:
-        php: [ "7.3", "7.4", "8.0", "8.1" ]
+        php: [ "7.3", "7.4", "8.0", "8.1", "8.2" ]
         os: [ ubuntu-latest ]
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -30,10 +30,10 @@
         "php": ">=7.2.5|^8.0",
         "guzzlehttp/guzzle": "^6.2|^7.0.1|^7.2",
         "aws/aws-sdk-php": "~3.0",
-        "illuminate/contracts": "^6.0|^7.0|^8.0|^9.0",
-        "illuminate/database": "^6.0|^7.0|^8.0|^9.0",
-        "illuminate/queue": "^6.0|7.0|^8.0|^9.0",
-        "illuminate/console": "^6.0|^7.0|^8.0|^9.0",
+        "illuminate/contracts": "^6.0|^7.0|^8.0|^9.0|^10.0",
+        "illuminate/database": "^6.0|^7.0|^8.0|^9.0|^10.0",
+        "illuminate/queue": "^6.0|^7.0|^8.0|^9.0|^10.0",
+        "illuminate/console": "^6.0|^7.0|^8.0|^9.0|^10.0",
         "twig/twig": "^3.0"
     },
     "require-dev": {


### PR DESCRIPTION
Fixes https://github.com/generationtux/php-healthz/issues/33.

Laravel 10 requires to update the `illuminate/*` dependencies to `v10.*` and also adding support for PHP `8.2`.